### PR TITLE
Big visible "DEV" indicator in header if a Sandbox API key is being used

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,10 @@
   <div v-else class="containing-element">
     <v-app>
       <byu-header home-url="https://vote.byu.edu">
-        <span slot="site-title">Frontend Template</span>
+        <span slot="site-title">
+          Frontend Template
+          <span v-if="isSandbox" class="sandbox-notification">DEV</span>
+        </span>
         <byu-user-info slot="user">
           <a slot="login" href="#login">Sign In</a>
           <a slot="logout" href="//api.byu.edu/logout">Sign Out</a>
@@ -88,6 +91,14 @@ import * as authn from '@byuweb/browser-oauth'
 export default class DefaultLayout extends Vue {
   @Mutation clearManualRefresh!: () => void
 
+  get isSandbox() {
+    return (
+      this.$store.state.user &&
+      this.$store.state.user.rawUserInfo &&
+      this.$store.state.user.rawUserInfo['http://wso2.org/claims/keytype'] === 'SANDBOX'
+    )
+  }
+
   get username() {
     return this.$store.state.username
   }
@@ -98,3 +109,13 @@ export default class DefaultLayout extends Vue {
   }
 }
 </script>
+
+<style lang="sass">
+.sandbox-notification
+  font-weight: bold
+  background-color: white
+  color: rgb(0, 46, 93)
+  padding: 5px 10px
+  margin-left: 0.5em
+  border-radius: 3px
+</style>


### PR DESCRIPTION
I think it's a good idea to have a clear visual indicator when using a sandbox clientId.

 1. When end users are testing, they don't have to worry they're hitting production
 2. If a developer switches to a prod clientId for whatever reason, the missing indicator will hopefully help them remember to switch back to a dev clientId before messing with production data.
(For that situation it would be nicer to have it the other way around, with a big, bold indicator saying, "Hey you're in production! Don't mess anything up!", but we don't want to accidentally blare that in an *actual* production environment)

This PR's initial version of adding this indicator looks like this:

![devmode](https://user-images.githubusercontent.com/5741887/70005613-7770a400-1527-11ea-80a6-6a1f091ec0b1.png)
