### PR TITLE
Merge "plugin" and "static" implicit-grant files

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,10 +39,6 @@ export default {
       {
         src: 'https://cdn.byu.edu/byu-theme-components/2.x.x/byu-theme-components.min.js',
         async: ''
-      },
-      {
-        src: '/implicit-grant-config.js',
-        type: 'module'
       }
     ]
   },

--- a/plugins/implicit-grant.js
+++ b/plugins/implicit-grant.js
@@ -1,6 +1,13 @@
 import * as authn from '@byuweb/browser-oauth'
 
 export default context => {
+  import(/* webpackIgnore: true */ 'https://cdn.byu.edu/browser-oauth-implicit/latest/implicit-grant.min.js').then(
+    implicit =>
+      fetch(`${context.base}config.json`)
+        .then(response => response.json())
+        .then(config => implicit.configure(config))
+  )
+
   // External library, so we cannot avoid "new" constructor
   // eslint-disable-next-line no-new
   new authn.AuthenticationObserver(({ state, token, user }) => {

--- a/static/implicit-grant-config.js
+++ b/static/implicit-grant-config.js
@@ -1,5 +1,0 @@
-import * as implicit from 'https://cdn.byu.edu/browser-oauth-implicit/latest/implicit-grant.min.js'
-
-fetch('/config.json')
-  .then(response => response.json())
-  .then(config => implicit.configure(config))


### PR DESCRIPTION
1. Put implicit grant logic in one file, instead of two
2. Fixes behavior if we ever have to host an implicit-grant front end in a sub-path, e.g. https://someoldsite.byu.edu/subpath/here-is-the-nuxt-app/