### PR TITLE
changed terraform backend s3 bucket name

### DIFF
--- a/terraform/dev/tfstate.tf
+++ b/terraform/dev/tfstate.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     encrypt        = true
-    bucket         = "terraform-state-storage-ACCOUNTID"
+    bucket         = "terraform-state-ACCOUNTID"
     dynamodb_table = "terraform-state-lock-ACCOUNTID"
     key            = "APPLICATION-NAME/terraform.tfstate"
     region         = "us-west-2"

--- a/terraform/prd/tfstate.tf
+++ b/terraform/prd/tfstate.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     encrypt        = true
-    bucket         = "terraform-state-storage-ACCOUNTID"
+    bucket         = "terraform-state-ACCOUNTID"
     dynamodb_table = "terraform-state-lock-ACCOUNTID"
     key            = "APPLICATION-NAME/terraform.tfstate"
     region         = "us-west-2"


### PR DESCRIPTION
I changed our custom code aws account setup repo. It changed the bucket name from `terraform-state-storage-<acct_num>` to `terraform-state-<acct_num>`

We might need to include instructions to make sure AWS account has been setup with our setup repo before trying to run terraform. Want me to put that in this PR?