### PR TITLE
More robust check for WSO2-generated 401 error

### DIFF
--- a/plugins/axios.ts
+++ b/plugins/axios.ts
@@ -11,8 +11,9 @@ export default (context: Context) => {
       // Explicit cancellation, so do not show "error" message
       return
     }
-    if (error.config && error.response?.status === 401) {
-      // WSO2 token expired (or otherwise invalidated)
+    if (error.config && error.response?.status === 401 && error.response?.data?.includes?.('code>90090')) {
+      // WSO2 "Invalid Credentials", "Token Expired", etc, are code "90090[X]".
+      // We don't bother parsing the full XML doc, just check if that chunk appears in the raw XML string
       // Auto-refresh should happen in iframe background in ./implicit-grant.js
       // If that fails, then we can't auto-refresh, so...
       const failDuringPost = error.config.method !== 'get'
@@ -21,9 +22,11 @@ export default (context: Context) => {
     }
 
     const text =
+      get(error, 'response.data.errorMessage') ||
       get(error, 'response.data.readable_message') ||
       get(error, 'response.data.metadata.validation_response.message') ||
       get(error, 'response.data.ResolveIdentityService.errors.0.message') ||
+      get(error, 'response.data.message') ||
       error.message ||
       'Unknown Error'
 


### PR DESCRIPTION
Differentiate between WSO2-generated 401, which can be solved by re-authenticating through CAS, and a 401 generated by the target service.