### PR TITLE
Set OAuth variables in build-time environment, not run-time file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,12 @@ This template includes the initial setup and scaffolding you need to create a fr
 12) Update the `.repo-meta.yml` file.
 13) Add the repo key from Codecov into `cb-buildspec.yml` and then run `cbsetup` locally to create a CodeBuild project.
 14) Add the Codecov badge to the README.
-15) Create `static/config.json` with the following format:
-
-```json
-{
-  "autoRefreshOnTimeout": true,
-  "clientId": "CLIENT_ID_GOES_HERE",
-  "callbackUrl": "CALLBACK_URL_GOES_HERE"
-}
-
-```
+15) For running locally, create a file named `.env` in this project's root directory:
+    ```dotenv
+    OAUTH_CLIENT_ID=[WSO2 OAuth client ID goes here]
+    OAUTH_CALLBACK_URL=[WSO2 OAuth callback URL goes here]
+    ```
+    Alternatively, you can use your IDE to set these environment variables.
 
 ## AppDynamics Setup
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,7 +26,6 @@ phases:
       - yarn lint
       # Build
       - echo Building
-      - 'echo "{\"autoRefreshOnTimeout\": true, \"clientId\": \"${OAUTH_CLIENT_ID}\", \"callbackUrl\": \"${OAUTH_CALLBACK_URL}\"}" > static/config.json'
       - yarn build
   post_build:
     commands:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,9 +1,15 @@
 const pkg = require('./package')
+require('dotenv').config()
 
 export default {
   mode: 'spa',
 
   env: {
+    oauth: {
+      autoRefreshOnTimeout: true,
+      clientId: process.env.OAUTH_CLIENT_ID,
+      callbackUrl: process.env.OAUTH_CALLBACK_URL
+    },
     appDynamicsKey: process.env.APP_DYNAMICS_KEY
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,7 @@ export default {
   mode: 'spa',
 
   env: {
-    oauth: {
+    oAuth: {
       autoRefreshOnTimeout: true,
       clientId: process.env.OAUTH_CLIENT_ID,
       callbackUrl: process.env.OAUTH_CALLBACK_URL

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@vue/test-utils": "^1.0.0-beta.32",
     "babel-eslint": "^10.1.0",
     "css-loader": "^3.4.2",
+    "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-config-standard": ">=14.1.1",

--- a/plugins/implicit-grant.ts
+++ b/plugins/implicit-grant.ts
@@ -6,7 +6,7 @@ import AuthRefreshRequired from '~/components/network/AuthRefreshRequired.vue'
 declare function __import__(url: string): Promise<any>
 
 export default (context: Context) => {
-  if (!context.env.oauth?.clientId) {
+  if (!context.env.oAuth?.clientId) {
     // $dialog isn't fully configured when this code runs, so setTimeout bumps this call to the end of the event queue
     setTimeout(() =>
       context.$dialog.error({
@@ -23,7 +23,7 @@ export default (context: Context) => {
   dynamicImportPolyfill.initialize()
   __import__(
     /* webpackIgnore: true */ 'https://cdn.byu.edu/browser-oauth-implicit/latest/implicit-grant.min.js'
-  ).then(implicit => implicit.configure(context.env.oauth))
+  ).then(implicit => implicit.configure(context.env.oAuth))
 
   // External library, so we cannot avoid "new" constructor
   // eslint-disable-next-line no-new

--- a/plugins/implicit-grant.ts
+++ b/plugins/implicit-grant.ts
@@ -6,14 +6,24 @@ import AuthRefreshRequired from '~/components/network/AuthRefreshRequired.vue'
 declare function __import__(url: string): Promise<any>
 
 export default (context: Context) => {
+  if (!context.env.oauth?.clientId) {
+    // $dialog isn't fully configured when this code runs, so setTimeout bumps this call to the end of the event queue
+    setTimeout(() =>
+      context.$dialog.error({
+        title: 'Configuration Error',
+        text: 'This site is not configured correctly',
+        persistent: true
+      })
+    )
+    console.error('OAuth environment variables (OAUTH_CLIENT_ID, OAUTH_CALLBACK_URL) not set')
+    return
+  }
+
   // TODO: If Edge ever natively supports dynamic imports (i.e. "import(xxx)" returns a Promise), then use native
   dynamicImportPolyfill.initialize()
-  __import__(/* webpackIgnore: true */ 'https://cdn.byu.edu/browser-oauth-implicit/latest/implicit-grant.min.js').then(
-    implicit =>
-      fetch(`${context.base}config.json`)
-        .then(response => response.json())
-        .then(config => implicit.configure(config))
-  )
+  __import__(
+    /* webpackIgnore: true */ 'https://cdn.byu.edu/browser-oauth-implicit/latest/implicit-grant.min.js'
+  ).then(implicit => implicit.configure(context.env.oauth))
 
   // External library, so we cannot avoid "new" constructor
   // eslint-disable-next-line no-new


### PR DESCRIPTION
While doing that AppDynamics thing, I realized that the original reasons we set up the OAuth credentials via a runtime process (i.e. "load config.json from a separate file when the site first loads") are no longer valid.
This refactor simplifies the build process *and* slightly speeds up site loading. Double win.