### PR TITLE
Change caching practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Cache node_modules
-        id: node-modules-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
-
       - name: Install
-        if: |
-          steps.yarn-cache.outputs.cache-hit != 'true' ||
-          steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --unsafe-perm --prefer-offline
+        run: yarn install --unsafe-perm --prefer-offline --frozen-lockfile
 
       - name: Test
         run: yarn test --coverage

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,20 +83,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Cache node_modules
-        id: node-modules-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
-
       - name: Install
         if: |
-          steps.yarn-cache.outputs.cache-hit != 'true' ||
-          steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --unsafe-perm --prefer-offline
+        run: yarn install --unsafe-perm --prefer-offline --frozen-lockfile
 
       - name: Build
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,7 +84,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install
-        if: |
         run: yarn install --unsafe-perm --prefer-offline --frozen-lockfile
 
       - name: Build


### PR DESCRIPTION
The GitHub cache action says "It is not recommended to cache node_modules, as it can break across Node versions and won't work with `npm ci`". We also should be using `npm ci` in our build to lock dependencies, but since we're using `yarn`, the closest alernative would be the `--frozen-lockfile` flag. Per the Yarn documentation: "If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.".
